### PR TITLE
Add handle return

### DIFF
--- a/Log/Engine/LogstashLog.php
+++ b/Log/Engine/LogstashLog.php
@@ -82,6 +82,7 @@ class LogstashLog extends BaseLog {
  */
 	protected function _open($host, $port, $timeout) {
 		$handle = pfsockopen($host, $port, $errNo, $errSt, $timeout);
+		return $handle;
 	}
 
 /**


### PR DESCRIPTION
Fixes the bug that occurred when the handle is initialized at the time of
writing.
The write function uses the return of the open function, but the open
function does not return anything.